### PR TITLE
docs: remove deprecated TheLastMonth from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ The configuration `config.json` contains following properties in `parameters` ke
     - `granularity` - enum (optional): One from: `None`, `Daily`, `Monthly`.
     - `incremental` - boolean (optional): Enables [Incremental Loading](https://help.keboola.com/storage/tables/#incremental-loading). Default `true`.
     - `timeDimension` - object (optional): Time dimensions of the export.
-        - `timeFrame` - enum (optional): One from: `MonthToDate` - default, `WeekToDate`, `BillingMonthToDate`, `TheLastMonth`, `TheLastBillingMonth`, `Custom`.
+        - `timeFrame` - enum (optional): One from: `MonthToDate` - default, `WeekToDate`, `BillingMonthToDate`, `TheLastBillingMonth`, `Custom`.
+            - **Note:** `TheLastMonth` is no longer supported by Azure Cost Management API. Use `TheLastBillingMonth` instead.
         - `start` - string (optional): Start date of the `Custom` time frame in `YYYY-MM-DD` format.
         - `end` - string (optional): End date of the `Custom` time frame in `YYYY-MM-DD` format.
 
@@ -116,4 +117,4 @@ docker-compose run --rm dev composer tests
 
 # Integration
 
-For information about deployment and integration with KBC, please refer to the [deployment section of developers documentation](https://developers.keboola.com/extend/component/deployment/)  
+For information about deployment and integration with KBC, please refer to the [deployment section of developers documentation](https://developers.keboola.com/extend/component/deployment/)    


### PR DESCRIPTION
# docs: remove deprecated TheLastMonth from README

## Summary
Updates README.md to remove `TheLastMonth` from the list of valid timeFrame options and adds a deprecation note explaining that Azure Cost Management API no longer supports this value. Users should use `TheLastBillingMonth` instead.

This is a documentation-only change related to SUPPORT-14111, where jobs fail with error: "Invalid query definition, timeframe TheLastMonth is currently not supported."

**Important:** This PR only updates documentation. The component code (ConfigDefinition.php) still includes `TheLastMonth` in the enum, and the Developer Portal UI configuration will be updated separately.

## Review & Testing Checklist for Human
- [ ] Verify the deprecation note clearly communicates that `TheLastMonth` is no longer supported
- [ ] Confirm the plan to update Developer Portal UI separately to remove `TheLastMonth` from the dropdown options
- [ ] Consider whether a runtime fix is needed (e.g., automatic mapping of TheLastMonth → TheLastBillingMonth for backward compatibility with existing configs)

### Notes
- **No code changes**: This PR intentionally does not modify ConfigDefinition.php or add runtime mapping, per user request
- **Related work needed**: Developer Portal UI schema must be updated to prevent users from selecting `TheLastMonth`
- **API version**: Component uses Azure Cost Management API version 2019-11-01 (from 2019). Consider creating a separate task to evaluate updating to a newer API version
- **Link to Devin run**: https://app.devin.ai/sessions/0cd4bd3358604be8ae5f32ebf83b4737
- **Requested by**: @ZdenekSrotyr (zdenek.srotyr@keboola.com)