### PR TITLE
Fix/debug ratelimit

### DIFF
--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -81,10 +81,28 @@ class Api
 
     private function doSendOneRequest(Request $request): ResponseInterface
     {
-        try {
-            return $this->client->send($request);
-        } catch (RequestException $e) {
-            throw $this->processException($request, $e);
+        while (true) {
+            try {
+                return $this->client->send($request);
+            } catch (RequestException $e) {
+                // Handle 429 with Retry-After header specially - don't count against retry limit
+                if ($e->getCode() === 429) {
+                    $retryAfter = $this->extractRetryAfterSeconds($e->getResponse());
+                    if ($retryAfter !== null) {
+                        $rateLimitInfo = $this->formatRateLimitHeaders($e->getResponse());
+                        $this->logger->info(sprintf(
+                            'Rate limit exceeded (429), waiting %d seconds before retry. %s',
+                            $retryAfter,
+                            $rateLimitInfo
+                        ));
+                        sleep($retryAfter);
+                        continue; // Retry immediately without counting against maxTries
+                    }
+                }
+
+                // All other errors go through normal exception processing
+                throw $this->processException($request, $e);
+            }
         }
     }
 
@@ -120,23 +138,12 @@ class Api
         }
 
         if ($exception->getCode() === 429) {
+            // 429 without Retry-After header - use exponential backoff (counts against maxTries)
             $rateLimitInfo = $this->formatRateLimitHeaders($exception->getResponse());
-            $retryAfter = $this->extractRetryAfterSeconds($exception->getResponse());
-
-            if ($retryAfter !== null) {
-                $this->logger->info(sprintf(
-                    'Rate limit exceeded (429), waiting %d seconds before retry. %s',
-                    $retryAfter,
-                    $rateLimitInfo
-                ));
-                sleep($retryAfter);
-            } else {
-                $this->logger->info(sprintf(
-                    'Rate limit exceeded (429), will retry with backoff. %s',
-                    $rateLimitInfo
-                ));
-            }
-
+            $this->logger->info(sprintf(
+                'Rate limit exceeded (429) without Retry-After header, will retry with backoff. %s',
+                $rateLimitInfo
+            ));
             return new ExportRequestRetryException($msg, $exception->getCode(), $exception);
         }
 

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -231,7 +231,7 @@ class Api
         // Check for the Azure Cost Management specific retry-after header
         $header = $response->getHeader('x-ms-ratelimit-microsoft.costmanagement-entity-retry-after');
         if (!empty($header)) {
-            return (int) $header[0];
+            return (int) $header[0] + 3;
         }
 
         return null;

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -121,10 +121,22 @@ class Api
 
         if ($exception->getCode() === 429) {
             $rateLimitInfo = $this->formatRateLimitHeaders($exception->getResponse());
-            $this->logger->info(sprintf(
-                'Rate limit exceeded (429), will retry with backoff. %s',
-                $rateLimitInfo
-            ));
+            $retryAfter = $this->extractRetryAfterSeconds($exception->getResponse());
+
+            if ($retryAfter !== null) {
+                $this->logger->info(sprintf(
+                    'Rate limit exceeded (429), waiting %d seconds before retry. %s',
+                    $retryAfter,
+                    $rateLimitInfo
+                ));
+                sleep($retryAfter);
+            } else {
+                $this->logger->info(sprintf(
+                    'Rate limit exceeded (429), will retry with backoff. %s',
+                    $rateLimitInfo
+                ));
+            }
+
             return new ExportRequestRetryException($msg, $exception->getCode(), $exception);
         }
 
@@ -201,6 +213,21 @@ class Api
         }
 
         return 'Rate limit headers: ' . implode('; ', $rateLimitHeaders);
+    }
+
+    private function extractRetryAfterSeconds(?ResponseInterface $response): ?int
+    {
+        if (!$response) {
+            return null;
+        }
+
+        // Check for the Azure Cost Management specific retry-after header
+        $header = $response->getHeader('x-ms-ratelimit-microsoft.costmanagement-entity-retry-after');
+        if (!empty($header)) {
+            return (int) $header[0];
+        }
+
+        return null;
     }
 
     private function createRetryProxy(): RetryProxy

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -81,6 +81,8 @@ class Api
 
     private function doSendOneRequest(Request $request): ResponseInterface
     {
+        $maxRateLimitRetries = 7;
+        $rateLimitRetries = 0;
         while (true) {
             try {
                 return $this->client->send($request);
@@ -89,14 +91,20 @@ class Api
                 if ($e->getCode() === 429) {
                     $retryAfter = $this->extractRetryAfterSeconds($e->getResponse());
                     if ($retryAfter !== null) {
+                        $rateLimitRetries++;
+                        if ($rateLimitRetries > $maxRateLimitRetries) {
+                            throw $this->processException($request, $e);
+                        }
                         $rateLimitInfo = $this->formatRateLimitHeaders($e->getResponse());
                         $this->logger->info(sprintf(
-                            'Rate limit exceeded (429), waiting %d seconds before retry. %s',
+                            'Rate limit exceeded (429), waiting %d seconds before retry (attempt %d/%d). %s',
                             $retryAfter,
+                            $rateLimitRetries,
+                            $maxRateLimitRetries,
                             $rateLimitInfo
                         ));
                         sleep($retryAfter);
-                        continue; // Retry immediately without counting against maxTries
+                        continue;
                     }
                 }
 
@@ -231,7 +239,7 @@ class Api
         // Check for the Azure Cost Management specific retry-after header
         $header = $response->getHeader('x-ms-ratelimit-microsoft.costmanagement-entity-retry-after');
         if (!empty($header)) {
-            return (int) $header[0] + 3;
+            return (int) $header[0] + 3; // waiting for 3 more seconds for safety
         }
 
         return null;

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -120,7 +120,11 @@ class Api
         }
 
         if ($exception->getCode() === 429) {
-            $this->logger->info('Rate limit exceeded (429), will retry with backoff.');
+            $rateLimitInfo = $this->formatRateLimitHeaders($exception->getResponse());
+            $this->logger->info(sprintf(
+                'Rate limit exceeded (429), will retry with backoff. %s',
+                $rateLimitInfo
+            ));
             return new ExportRequestRetryException($msg, $exception->getCode(), $exception);
         }
 
@@ -177,6 +181,26 @@ class Api
         }
 
         return true;
+    }
+
+    private function formatRateLimitHeaders(?ResponseInterface $response): string
+    {
+        if (!$response) {
+            return '';
+        }
+
+        $rateLimitHeaders = [];
+        foreach ($response->getHeaders() as $name => $values) {
+            if (stripos($name, 'x-ms-ratelimit') === 0) {
+                $rateLimitHeaders[] = sprintf('%s: %s', $name, implode(', ', $values));
+            }
+        }
+
+        if (empty($rateLimitHeaders)) {
+            return '';
+        }
+
+        return 'Rate limit headers: ' . implode('; ', $rateLimitHeaders);
     }
 
     private function createRetryProxy(): RetryProxy


### PR DESCRIPTION
**Change:**
- Properly wait based on the x-ms-ratelimit-microsoft.costmanagement-entity-retry-after value
tested in https://keboola.atlassian.net/browse/SUPPORT-14945